### PR TITLE
Add support for new SoapClient option: keep_alive and ssl_method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,12 +100,12 @@ class Client implements ServerClient
     /**
      * @var int[]
      */
-    protected static $supportedSslMethods = array(
+    protected static $supportedSslMethods = [
         SOAP_SSL_METHOD_TLS,
         SOAP_SSL_METHOD_SSLv2,
         SOAP_SSL_METHOD_SSLv3,
         SOAP_SSL_METHOD_SSLv23
-    );
+    ];
 
     /**#@+
      * @var string

--- a/src/Client.php
+++ b/src/Client.php
@@ -97,16 +97,6 @@ class Client implements ServerClient
      */
     protected $sslMethod;
 
-    /**
-     * @var int[]
-     */
-    protected static $supportedSslMethods = [
-        SOAP_SSL_METHOD_TLS,
-        SOAP_SSL_METHOD_SSLv2,
-        SOAP_SSL_METHOD_SSLv3,
-        SOAP_SSL_METHOD_SSLv23
-    ];
-
     /**#@+
      * @var string
      */
@@ -1279,13 +1269,6 @@ class Client implements ServerClient
      */
     public function setSslMethod($sslMethod)
     {
-        if (!in_array($sslMethod, static::$supportedSslMethods, true)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid SSL method specified. Use one of %s constants.',
-                'SOAP_SSL_METHOD_TLS, SOAP_SSL_METHOD_SSLv2, SOAP_SSL_METHOD_SSLv3, SOAP_SSL_METHOD_SSLv23'
-            ));
-        }
-
         $this->sslMethod = $sslMethod;
         return $this;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1281,8 +1281,8 @@ class Client implements ServerClient
     {
         if (!in_array($sslMethod, static::$supportedSslMethods, true)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid SSL method specified. Use on of %s constants.',
-                implode(', ', static::$supportedSslMethods)
+                'Invalid SSL method specified. Use one of %s constants.',
+                'SOAP_SSL_METHOD_TLS, SOAP_SSL_METHOD_SSLv2, SOAP_SSL_METHOD_SSLv3, SOAP_SSL_METHOD_SSLv23'
             ));
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -83,6 +83,30 @@ class Client implements ServerClient
      */
     protected $wsdl = null;
 
+    /**
+     * Whether to send the "Connection: Keep-Alive" header (true) or "Connection: close" header (false)
+     * Available since PHP 5.4.0
+     * @var bool
+     */
+    protected $keepAlive;
+
+    /**
+     * One of SOAP_SSL_METHOD_TLS, SOAP_SSL_METHOD_SSLv2, SOAP_SSL_METHOD_SSLv3 or SOAP_SSL_METHOD_SSLv23
+     * Available since PHP 5.5.0
+     * @var int
+     */
+    protected $sslMethod;
+
+    /**
+     * @var int[]
+     */
+    protected static $supportedSslMethods = array(
+        SOAP_SSL_METHOD_TLS,
+        SOAP_SSL_METHOD_SSLv2,
+        SOAP_SSL_METHOD_SSLv3,
+        SOAP_SSL_METHOD_SSLv23
+    );
+
     /**#@+
      * @var string
      */
@@ -275,6 +299,16 @@ class Client implements ServerClient
                     $this->connectionTimeout = $value;
                     break;
 
+                case 'keepalive':
+                case 'keep_alive':
+                    $this->setKeepAlive($value);
+                    break;
+
+                case 'sslmethod':
+                case 'ssl_method':
+                    $this->setSslMethod($value);
+                    break;
+
                 default:
                     throw new Exception\InvalidArgumentException('Unknown SOAP client option');
             }
@@ -315,6 +349,8 @@ class Client implements ServerClient
         $options['cache_wsdl']     = $this->getWSDLCache();
         $options['features']       = $this->getSoapFeatures();
         $options['user_agent']     = $this->getUserAgent();
+        $options['keep_alive']     = $this->getKeepAlive();
+        $options['ssl_method']     = $this->getSslMethod();
 
         foreach ($options as $key => $value) {
             /*
@@ -1209,5 +1245,56 @@ class Client implements ServerClient
         $soapClient = $this->getSoapClient();
         $soapClient->__setCookie($cookieName, $cookieValue);
         return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getKeepAlive()
+    {
+        return $this->keepAlive;
+    }
+
+    /**
+     * @param boolean $keepAlive
+     * @return self
+     */
+    public function setKeepAlive($keepAlive)
+    {
+        $this->keepAlive = (bool) $keepAlive;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSslMethod()
+    {
+        return $this->sslMethod;
+    }
+
+    /**
+     * @param int $sslMethod
+     * @return self
+     */
+    public function setSslMethod($sslMethod)
+    {
+        if (!in_array($sslMethod, static::$supportedSslMethods, true)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid SSL method specified. Use on of %s constants.',
+                implode(', ', static::$supportedSslMethods)
+            ));
+        }
+
+        $this->sslMethod = $sslMethod;
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public static function getSupportedSslMethods()
+    {
+        return static::$supportedSslMethods;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1289,12 +1289,4 @@ class Client implements ServerClient
         $this->sslMethod = $sslMethod;
         return $this;
     }
-
-    /**
-     * @return int[]
-     */
-    public static function getSupportedSslMethods()
-    {
-        return static::$supportedSslMethods;
-    }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -588,6 +588,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Zend\Soap\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid SSL method specified.
      */
     public function testSetInvalidSslMethod()
     {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -618,7 +618,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             array_values($sslMethodConstantsValues),
-            \PHPUnit_Framework_Assert::readAttribute('Zend\Soap\Client', 'supportedSslMethods')
+            self::readAttribute('Zend\Soap\Client', 'supportedSslMethods')
         );
     }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -616,7 +616,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         // get constants values
         $sslMethodConstantsValues = array_intersect_key($soapConstants, array_flip($sslMethodsConstants));
 
-        $this->assertEquals(array_values($sslMethodConstantsValues), Client::getSupportedSslMethods());
+        $this->assertEquals(
+            array_values($sslMethodConstantsValues),
+            \PHPUnit_Framework_Assert::readAttribute('Zend\Soap\Client', 'supportedSslMethods')
+        );
     }
 
     /**

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -601,10 +601,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllSslMethodsAreSupported()
     {
-        if (!version_compare(PHP_VERSION, '5.5.0', '>=')) {
-            $this->markTestSkipped('SSL method option is available since PHP 5.5');
-        }
-
         $constants = get_defined_constants(true);
         $soapConstants = $constants['soap'];
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -81,7 +81,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                                 'compression'    => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5,
                                 'typemap'        => $typeMap,
                                 'keep_alive'     => true,
-                                'ssl_method'     => SOAP_SSL_METHOD_SSLv23,
+                                'ssl_method'     => 3,
         ];
 
         $client->setOptions($nonWSDLOptions);
@@ -116,7 +116,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                              'compression'    => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5,
                              'typemap'        => $typeMap,
                              'keep_alive'     => true,
-                             'ssl_method'     => SOAP_SSL_METHOD_SSLv23,
+                             'ssl_method'     => 3,
         ];
 
         $client1->setOptions($wsdlOptions);
@@ -169,7 +169,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                          'compression'    => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5,
                          'typemap'        => $typeMap,
                          'keep_alive'     => true,
-                         'ssl_method'     => SOAP_SSL_METHOD_SSLv23,
+                         'ssl_method'     => 3,
         ];
 
         $client->setOptions($options);
@@ -584,42 +584,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $soap->setSoapClient($clientMock);
 
         $this->assertSame($clientMock, $soap->getSoapClient());
-    }
-
-    /**
-     * @expectedException \Zend\Soap\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid SSL method specified.
-     */
-    public function testSetInvalidSslMethod()
-    {
-        new Client(null, [
-            'ssl_method' => 'invalid',
-        ]);
-    }
-
-    /**
-     * Are all SSL method constants defined in SOAP extension supported?
-     */
-    public function testAllSslMethodsAreSupported()
-    {
-        $constants = get_defined_constants(true);
-        $soapConstants = $constants['soap'];
-
-        // filter all constant names started with 'SOAP_SSL_METHOD_' string
-        $sslMethodsConstants = array_filter(
-            array_keys($soapConstants),
-            function ($constantName) {
-                return (strpos($constantName, 'SOAP_SSL_METHOD_') === 0);
-            }
-        );
-
-        // get constants values
-        $sslMethodConstantsValues = array_intersect_key($soapConstants, array_flip($sslMethodsConstants));
-
-        $this->assertEquals(
-            array_values($sslMethodConstantsValues),
-            self::readAttribute('Zend\Soap\Client', 'supportedSslMethods')
-        );
     }
 
     /**


### PR DESCRIPTION
This PR adds two `SoapClient` options introduced in PHP 5.4 and 5.5:

`keep_alive` option allows sending "Connection: close" header directly from SoapClient.

`ssl_method` option allows to specify the SSL version to use
