### PR TITLE
HHVM complaining about wrong parameter

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1111,8 +1111,8 @@ class Client implements ServerClient
         $result = $soapClient->__soapCall(
             $name,
             $this->_preProcessArguments($arguments),
-            null, /* Options are already set to the SOAP client object */
-            (count($soapHeaders) > 0)? $soapHeaders : null,
+            array(), /* Options are already set to the SOAP client object */
+            (count($soapHeaders) > 0)? $soapHeaders : array(),
             $this->soapOutputHeaders
         );
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1111,8 +1111,8 @@ class Client implements ServerClient
         $result = $soapClient->__soapCall(
             $name,
             $this->_preProcessArguments($arguments),
-            array(), /* Options are already set to the SOAP client object */
-            (count($soapHeaders) > 0)? $soapHeaders : array(),
+            [], /* Options are already set to the SOAP client object */
+            (count($soapHeaders) > 0)? $soapHeaders : [],
             $this->soapOutputHeaders
         );
 


### PR DESCRIPTION
According to php documentation http://php.net/manual/fr/soapclient.soapcall.php, __soapCall should take array instead of null parameters.

HHVM 3.8.0 is complaining resulting a wrong result with message :
Warning: __soapcall() expects parameter 3 to be array, NULL given in /zendframework/library/Zend/Soap/Client.php on line 1117

This PR work with hhvm & php