### PR TITLE
Fix warning when request is empty string

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -744,6 +744,10 @@ class Server implements ZendServerServer
             }
             $xml = trim($xml);
 
+            if (strlen($xml) === 0) {
+                throw new Exception\InvalidArgumentException('Empty request');
+            }
+
             $loadEntities = libxml_disable_entity_loader(true);
 
             $dom = new DOMDocument();
@@ -752,7 +756,7 @@ class Server implements ZendServerServer
             libxml_disable_entity_loader($loadEntities);
 
             // @todo check libxml errors ? validate document ?
-            if (strlen($xml) == 0 || !$loadStatus) {
+            if (!$loadStatus) {
                 throw new Exception\InvalidArgumentException('Invalid XML');
             }
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -644,6 +644,20 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedResponse, $server1->handle($request));
     }
 
+    public function testEmptyRequest()
+    {
+        $server = new Server();
+        $server->setOptions(['location'=>'test://', 'uri'=>'http://framework.zend.com']);
+        $server->setReturnResponse(true);
+
+        $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass');
+
+        $request = '';
+        $response = $server->handle($request);
+
+        $this->assertContains('Empty request', $response->getMessage());
+    }
+
     /**
      * @dataProvider dataProviderForRegisterFaultException
      *


### PR DESCRIPTION
Without this I get warning:

```
PHP Warning:  DOMDocument::loadXML(): Empty string supplied as input in src/Server.php on line 750
```