### PR TITLE
send_errors option of SoapServer added

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -146,6 +146,12 @@ class Server implements ZendServerServer
     protected $wsdlCache;
 
     /**
+     * The send_errors Options of SOAP Server
+     * @var bool
+     */
+    protected $sendErrors;
+
+    /**
      * Constructor
      *
      * Sets display_errors INI setting to off (prevent client errors due to bad
@@ -229,6 +235,10 @@ class Server implements ZendServerServer
                     $this->setSoapFeatures($value);
                     break;
 
+                case 'send_errors':
+                    $this->setSendErrors($value);
+                    break;
+
                 default:
                     break;
             }
@@ -277,6 +287,10 @@ class Server implements ZendServerServer
             $options['cache_wsdl'] = $this->getWSDLCache();
         }
 
+        if (null !== $this->sendErrors) {
+            $options['send_errors'] = $this->getSendErrors();
+        }
+        
         return $options;
     }
 
@@ -534,6 +548,26 @@ class Server implements ZendServerServer
     public function getWSDLCache()
     {
         return $this->wsdlCache;
+    }
+
+    /**
+     * Set the SOAP send_errors Option
+     *
+     * @param  bool $sendErrors
+     * @return self
+     */
+    public function setSendErrors($sendErrors)
+    {
+        $this->sendErrors = $sendErrors;
+        return $this;
+    }
+
+    /**
+     * Get current SOAP send_errors option
+     */
+    public function getSendErrors()
+    {
+        return $this->sendErrors;
     }
 
     /**


### PR DESCRIPTION
send_errors option of \SoapServer added (http://php.net/manual/de/soapserver.soapserver.php)

Without this option, Fatal errors are always printed out by \SoapServer