### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "O2ECNTc7cif3sN3Iyjiheu4UsHcs4g/TrNtc5XqcTpecxcM4ncG1oLAoF62ZN2cwdpJ8nBwl3BQDI9nkLS+nxPHxdqV5bobZ/8ZcI1/2by+l9N720WQfezPxxSxAAPl5b1SXxocsWUiykJJpADqGdYjgfmgAyiK70tXN4XwZl27Svnh+ulqFB2aYQNUv28jJZ3/Pt8jW5sgTVYKYZ65bYirEHGMsUnOK5nJ/W04qoq1d8Qj5x4xTrA71KecibljXpqXHtrQRBpGoKmU8N0w7XdGn0l6xojEJ3QkLE1/1SrZq0r4GHgP294358IsepdQXoqAIxULR0nlNkLmDY//wQI6WRWOpTI+eYN+unoq/zDgPnZGzV6NX/BrRt1yxhNij8CpIvR8cg4WP52Cl2djG5YWr5sOOqffIvSDKJLZgUOb512F7DdI2Pr6HSDyOSqrKoMGMpLJb7/1sEumLfVGmpu9fgpWakxR5wTa0oMBZknyJVy18nj+mj5YgIzD+1FYzYj5ttajh3KKaxDgTCYHJkCA/MRONsr/Ap1oHI2W5iDgAEyaJhru0XefNjW37n/sx3QqZ+F4VZDbuTy8FaFMbnT6+brbCLdrxtmIwo2OhYob+G5rWQejnF81g1ShUE/H3l/rlQ+BLZzwYEgAHkJ5YTAQYq37E3Ra7DgOv14Ayjvo="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
