### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/server.md
+++ b/doc/book/server.md
@@ -24,7 +24,7 @@ WSDL mode.
 
 ### Instantiation for WSDL mode
 
-When in WSDL mode, the constructor expects two optional paramters:
+When in WSDL mode, the constructor expects two optional parameters:
 
 - `$wsdl`: the URI of a WSDL file. This may be set after-the-fact using
   `$server->setWsdl($wsdl)`.


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.