### PR TITLE
Remove unused arguments from Server::handlePhpErrors

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -1146,12 +1146,9 @@ class Server implements ZendServerServer
      *
      * @param  int $errno
      * @param  string $errstr
-     * @param  string $errfile
-     * @param  int $errline
-     * @param  array $errcontext
      * @throws SoapFault
      */
-    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handlePhpErrors($errno, $errstr)
     {
         throw $this->fault($errstr, 'Receiver');
     }


### PR DESCRIPTION
Per #47, the `$errcontext` argument to an error handler callback is deprecated in PHP 7.2. Since we do not use any past `$errstr`, we can remove them, ensuring we do not trigger any deprecation notices.

Fixes #47