### PR TITLE
Add support for xsd:dateTime

### DIFF
--- a/doc/book/wsdl.md
+++ b/doc/book/wsdl.md
@@ -193,6 +193,8 @@ and SOAP types:
 - PHP floats and doubles &lt;-&gt; `xsd:float`.
 - PHP booleans &lt;-&gt; `xsd:boolean`.
 - PHP arrays &lt;-&gt; `soap-enc:Array`.
+- PHP Date &lt;-&gt; `xsd:date`.
+- PHP DateTime &lt;-&gt; `xsd:dateTime`.
 - PHP object &lt;-&gt; `xsd:struct`.
 - PHP class &lt;-&gt; based on complex type strategy (See
   [the section on adding complex types](#adding-complex-type-information)).

--- a/src/Wsdl.php
+++ b/src/Wsdl.php
@@ -698,6 +698,9 @@ class Wsdl
             case 'date':
                 return self::XSD_NS . ':date';
 
+            case 'datetime':
+                return self::XSD_NS . ':dateTime';
+
             case 'void':
                 return '';
 

--- a/test/WsdlTest.php
+++ b/test/WsdlTest.php
@@ -632,6 +632,7 @@ class WsdlTest extends WsdlTestHelper
         $this->assertEquals('xsd:struct', $this->wsdl->getType('object'), 'xsd:struct detection failed.');
         $this->assertEquals('xsd:anyType', $this->wsdl->getType('mixed'), 'xsd:anyType detection failed.');
         $this->assertEquals('xsd:date', $this->wsdl->getType('date'), 'xsd:date detection failed.');
+        $this->assertEquals('xsd:dateTime', $this->wsdl->getType('datetime'), 'xsd:dateTime detection failed.');
         $this->assertEquals('', $this->wsdl->getType('void'), 'void  detection failed.');
     }
 


### PR DESCRIPTION
This PR adds support for the `xsd:dateTime` type. 

It seems like an omission - `xsd:date` is already supported - so I've made this against master. Let me know if should be against develop instead.