### PR TITLE
Check valid value for Client cacheWSDL property

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -890,14 +890,16 @@ class Client implements ServerClient
      *
      * @param  string|int|bool|null $caching
      * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function setWSDLCache($caching)
     {
-        //@todo check WSDL_CACHE_* constants?
         if ($caching === null) {
             $this->cacheWsdl = null;
-        } else {
+        } elseif (in_array($caching, [WSDL_CACHE_NONE, WSDL_CACHE_DISK, WSDL_CACHE_MEMORY, WSDL_CACHE_BOTH])) {
             $this->cacheWsdl = (int) $caching;
+        } else {
+            throw new Exception\InvalidArgumentException("Invalid value for cache_wsdl option");
         }
 
         return $this;

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -71,7 +71,7 @@ class ClientTest extends TestCase
                                 'passphrase'     => 'some pass phrase',
 
                                 'stream_context' => $ctx,
-                                'cache_wsdl'     => 8,
+                                'cache_wsdl'     => WSDL_CACHE_NONE,
                                 'features'       => 4,
 
                                 'compression'    => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP | 5,
@@ -242,6 +242,15 @@ class ClientTest extends TestCase
         $this->assertNull($client->getWsdlCache());
         $options = $client->getOptions();
         $this->assertArrayNotHasKey('cache_wsdl', $options);
+    }
+
+    /**
+     * @expectedException \Zend\Soap\Exception\InvalidArgumentException
+     */
+    public function testInvalidCacheWsdlOptionException()
+    {
+        $client = new Client();
+        $client->setWsdlCache(100);
     }
 
     /**


### PR DESCRIPTION
Checks for WSDL_CACHE_* valid constants at Client::setWSDLCache method
